### PR TITLE
add index idx_blocks_slot_errors

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -31,8 +31,10 @@ CREATE INDEX idx_blocks_slot ON banking_stage_results.blocks(slot);
 -- optional
 CLUSTER banking_stage_results.blocks using idx_blocks_slot;
 VACUUM FULL banking_stage_results.blocks;
+CREATE INDEX idx_blocks_slot_errors ON banking_stage_results.blocks(slot) WHERE banking_stage_errors > 0;
 
 CREATE INDEX idx_transaction_infos_timestamp ON banking_stage_results.transaction_infos(utc_timestamp);
 -- optional
 CLUSTER banking_stage_results.transaction_infos using idx_transaction_infos_timestamp;
 VACUUM FULL banking_stage_results.transaction_infos;
+


### PR DESCRIPTION
index is used here:

```SQL
SELECT * FROM (
    SELECT
        ROW_NUMBER() OVER () AS pos,
        slot,
        processed_transactions,
        successful_transactions,
        banking_stage_errors,
        total_cu_used,
        total_cu_requested
    FROM banking_stage_results.blocks
    -- this critera uses index idx_blocks_slot_errors
    WHERE banking_stage_errors > 0
    ORDER BY slot DESC
    LIMIT 30
) AS data
```